### PR TITLE
src, example: Use correct module syntax

### DIFF
--- a/example/src/lib.rs
+++ b/example/src/lib.rs
@@ -5,7 +5,6 @@ use pyo3::{prelude::*, wrap_pyfunction};
 
 use cpy_binder::export_cpy;
 
-#[rustfmt::skip]
 export_cpy!(
     mod example {
         enum Material {

--- a/example/src/lib.rs
+++ b/example/src/lib.rs
@@ -7,7 +7,7 @@ use cpy_binder::export_cpy;
 
 #[rustfmt::skip]
 export_cpy!(
-    example {
+    mod example {
         enum Material {
             Plastic,
             Rubber,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 #[macro_export]
 macro_rules! export_cpy {
-    ($module_name:ident { $($item:tt)* }) => {
+    (mod $module_name:ident { $($item:tt)* }) => {
         export_cpy!(@inner $($item)*);
 
         #[cfg(feature = "python")]


### PR DESCRIPTION
Closes #2 

With his change, the code inside `export_cpy!` is correctly parsed and formatted :)