### PR TITLE
Organizing 

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,17 +12,19 @@ macro_rules! export_cpy {
     };
     (@process_item) => {};
     (@process_item enum $name:ident { $($variant:ident,)* } $($rest:tt)*) => {
+        export_cpy!(@generate_enum $name { $($variant,)* });
         export_cpy!(@process_item $($rest)*);
     };
     (@process_item struct $name:ident { $($field:ident : $ftype:ty,)* } $($rest:tt)*) => {
-        export_cpy!(@struct $name { $($field : $ftype,)* });
+        export_cpy!(@generate_struct $name { $($field : $ftype,)* });
         export_cpy!(@process_item $($rest)*);
     };
     (@process_item fn $name:ident() $(-> $ret:ty)? $body:block $($rest:tt)*) => {
-        export_cpy!(@fn $name() $(-> $ret)? $body);
+        export_cpy!(@generate_function $name() $(-> $ret)? $body);
         export_cpy!(@process_item $($rest)*);
     };
 
+    (@generate_enum $name:ident { $($variant:ident,)* }) => {
         #[derive(Clone, Debug)]
         #[repr(C)]
         #[cfg_attr(feature = "python", pyo3::prelude::pyclass)]
@@ -32,7 +34,7 @@ macro_rules! export_cpy {
             )*
         }
     };
-    (@struct $name:ident { $($field:ident : $ftype:ty,)* }) => {
+    (@generate_struct $name:ident { $($field:ident : $ftype:ty,)* }) => {
         #[derive(Clone, Debug)]
         #[repr(C)]
         #[cfg_attr(feature = "python", pyo3::prelude::pyclass(get_all, set_all))]
@@ -42,7 +44,7 @@ macro_rules! export_cpy {
             )*
         }
     };
-    (@fn $name:ident() $(-> $ret:ty)? $body:block) => {
+    (@generate_function $name:ident() $(-> $ret:ty)? $body:block) => {
         #[no_mangle]
         #[cfg_attr(feature = "python", pyfunction)]
         pub extern "C" fn $name() $(-> $ret)? {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,13 @@
 #[macro_export]
 macro_rules! export_cpy {
+    //(0) - Entry point of the macro.
+    //      Matches the module name and block of items.
+    //      It exports Python related modules only if required,
+    //      see the examples.
+    //      Each type have a well defined scope, in sections:
+    //      (1) - Processing
+    //      (2) - Structure
+    //      (3) - Python Module Binding
     (mod $module_name:ident { $($item:tt)* }) => {
         export_cpy!(@process_item $($item)*);
 
@@ -10,6 +18,8 @@ macro_rules! export_cpy {
             Ok(())
         }
     };
+
+    //(1) - This section defines the processing items patterns
     (@process_item) => {};
     (@process_item enum $name:ident { $($variant:ident,)* } $($rest:tt)*) => {
         export_cpy!(@generate_enum $name { $($variant,)* });
@@ -24,6 +34,7 @@ macro_rules! export_cpy {
         export_cpy!(@process_item $($rest)*);
     };
 
+    //(1) - This section defines the structure of the itens
     (@generate_enum $name:ident { $($variant:ident,)* }) => {
         #[derive(Clone, Debug)]
         #[repr(C)]
@@ -51,6 +62,8 @@ macro_rules! export_cpy {
             $body
         }
     };
+
+    //(3) - This section defines the bindings to be exported to Python module
     (@add_py_binding $m:ident,) => {};
     (@add_py_binding $m:ident, enum $name:ident { $($variant:ident,)* } $($rest:tt)*) => {
         $m.add_class::<$name>()?;


### PR DESCRIPTION
This PR suggests reorganize the macro.
The proposal involves:

**Adjusting the order to align with the typical flow used in PyO3 applications**

**Renaming certain methods**
@ inner to process_item.
@ struct,enum,fn to generate_structure and so on.
@ class to add_py_binding

