### PR TITLE
example: python: pyproject: fix pyproject name

### DIFF
--- a/example/pyproject.toml
+++ b/example/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["maturin>=0.14,<0.15"]
 build-backend = "maturin"
 
 [project]
-name = "cpyexample"
+name = "example"
 requires-python = ">=3.7"
 classifiers = [
     "Programming Language :: Rust",


### PR DESCRIPTION
Current pyproject isn't working, the whell was build but not able to link, this fix it.