### PR TITLE
src: lib: Remove unnecessary extra curl brackets on functions generator

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,9 +58,8 @@ macro_rules! export_cpy {
     (@generate_function $name:ident($($arg:ident: $arg_type:ty),*) $(-> $ret:ty)? $body:block) => {
         #[no_mangle]
         #[cfg_attr(feature = "python", pyfunction)]
-        pub extern "C" fn $name($($arg: $arg_type),*) $(-> $ret)? {
+        pub extern "C" fn $name($($arg: $arg_type),*) $(-> $ret)?
             $body
-        }
     };
 
     //(3) - This section defines the bindings to be exported to Python module


### PR DESCRIPTION
Previous version macro output for functions:
```
#[no_mangle]
#[cfg_attr(feature = "python", pyfunction)]
pub extern "C" fn self_test() -> bool {
    {
        NavigationManager::get_instance()
            .lock()
            .unwrap()
            .as_mut()
            .unwrap()
            .navigator
            .self_test()
    }
}

```

After commit:
```
#[no_mangle]
#[cfg_attr(feature = "python", pyfunction)]
pub extern "C" fn self_test() -> bool {
    NavigationManager::get_instance()
        .lock()
        .unwrap()
        .as_mut()
        .unwrap()
        .navigator
        .self_test()
}
```