### PR TITLE
github: workflows: Add automatic crates.io deploy job

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -82,18 +82,28 @@ jobs:
         publish_dir: ./target/doc
 
   deploy-cargo:
-    needs: quick-tests
+    needs: deploy-doc
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/')
     steps:
-    - uses: actions/checkout@master
-    - uses: actions-rs/toolchain@v1.0.6
-      with:
-        toolchain: nightly
-        override: true
-        components: rustfmt, clippy
-    - name: Build
-      run: cargo build
-    - uses: katyo/publish-crates@v1
-      with:
-        registry-token: ${{ secrets.CARGO }}
+      - name: Checkout to repository
+        uses: actions/checkout@v2
+      - name: Setup Rust toolchain 
+        uses: actions-rs/toolchain@v1.0.7
+        with:
+          toolchain: nightly
+          override: true
+          components: rustfmt, clippy
+      - name: Install cargo-bump
+        run: cargo install cargo-bump --force
+      - name: Modify version with tag
+        run: cargo bump ${{ github.ref_name }}
+      - name: Automatic commit for crate version upgrade 
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          branch: master
+          commit_message: "Cargo: Update the crate version to ${{ github.ref_name }}"
+      - name: Publish to crates.io
+        uses: katyo/publish-crates@v1
+        with:
+          registry-token: ${{ secrets.CARGO }}


### PR DESCRIPTION
Fix this kind of issues,

- [ ] https://github.com/patrickelectric/cpy-rs/actions/runs/5626582352

![image](https://github.com/patrickelectric/cpy-rs/assets/80598030/aa398aef-8ffe-4a65-8689-cc916842ff1b)

Updates the version based on the release tag.